### PR TITLE
handler cannot exported twice in a route it will fail during build

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -10,6 +10,6 @@ export const authOptions = {
   ],
 };
 
-export const handler = NextAuth(authOptions);
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };


### PR DESCRIPTION
This implementation will fail during build because handler is being exported twice:
```ts
export const handler = NextAuth(authOptions);
export { handler as GET, handler as POST };
```
handler should be exported only once
```ts
const handler = NextAuth(authOptions);
export { handler as GET, handler as POST };
```
